### PR TITLE
Make it work on Safari.

### DIFF
--- a/addon/mixins/form-data-adapter.js
+++ b/addon/mixins/form-data-adapter.js
@@ -11,7 +11,7 @@ export default Ember.Mixin.create({
 
     var hash = this._super.apply(this, arguments);
 
-    if (typeof FormData === 'function' && data && this.formDataTypes.contains(type)) {
+    if (typeof FormData !== 'undefined' && data && this.formDataTypes.contains(type)) {
       var formData = new FormData();
       var root = Ember.keys(data)[0];
 


### PR DESCRIPTION
typeof FormData does not return 'function' on Safari, but 'object'. Wouldn't it be better to only test for FormData not undefined?