### PR TITLE
Improving customization

### DIFF
--- a/addon/mixins/form-data-adapter.js
+++ b/addon/mixins/form-data-adapter.js
@@ -13,13 +13,16 @@ export default Ember.Mixin.create({
 
     if (typeof FormData !== 'undefined' && data && this.formDataTypes.contains(type)) {
       var formData = new FormData();
-      var root = Ember.keys(data)[0];
+      var fields = this.getDataToTransform(data);
 
-      Ember.keys(data[root]).forEach(function(key) {
-        if (typeof data[root][key] !== 'undefined') {
-          formData.append(root + "[" + key + "]", data[root][key]);
+      Ember.keys(fields).forEach(function(key) {
+        if (typeof fields[key] !== 'undefined') {
+          formData.append(
+            this.getFormKey(key, fields),
+            this.getFormValue(key, fields)
+          );
         }
-      });
+      }.bind(this));
 
       hash.processData = false;
       hash.contentType = false;
@@ -28,4 +31,19 @@ export default Ember.Mixin.create({
 
     return hash;
   },
+
+  getDataToTransform: function (data) {
+    var root = Ember.keys(data)[0];
+    return data[root];
+  },
+
+  getFormKey: function (key, data) {
+    this._root = this._root || Ember.keys(data)[0];
+    return this._root + "[" + key + "]";
+  },
+
+  getFormValue: function (key, data) {
+    this._root = this._root || Ember.keys(data)[0];
+    return data[this._root][key];
+  }
 });


### PR DESCRIPTION
In a project I'm working on, we choose to not wrap server responses. FormData Adapter seems pretty good but it assumes a rooted serialization. This alternative implementation does the same but allows the developer for further customization of **what to be serialized** into form data and how this serialization must to be done. What do you think?

Thanks for the plugin anyway!