### PR TITLE
Add configuration flag to 'flatten' the form data fields in the payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ model.save();
 
 This will send the ``attachment`` and all other attributes as a FormData object.
 
+
+### Flatten FormData fields
+
+Some api's desire the form data fields to not include the root object
+name. For example, the default adapter behavior would result in ``post[title]``
+in your serialized data.  If your api instead expects just ``title``,
+add ``disableRoot: true`` to remove the model name from the fields.
+
 ### Thanks
 
 This addon was inspired by Matt Beedle's blog post http://blog.mattbeedle.name/posts/file-uploads-in-ember-data/

--- a/addon/mixins/form-data-adapter.js
+++ b/addon/mixins/form-data-adapter.js
@@ -4,8 +4,12 @@ export default Ember.Mixin.create({
   // Overwrite to change the request types on which Form Data is sent
   formDataTypes: ['POST', 'PUT', 'PATCH'],
 
+  // Overwrite to flatten the form data by removing the root
+  disableRoot: false,
+
   ajaxOptions: function(url, type, options) {
     var data;
+    var _this = this;
 
     if (options && 'data' in options) { data = options.data; }
 
@@ -17,7 +21,11 @@ export default Ember.Mixin.create({
 
       Ember.keys(data[root]).forEach(function(key) {
         if (typeof data[root][key] !== 'undefined') {
-          formData.append(root + "[" + key + "]", data[root][key]);
+          if ( _this.get('disableRoot') ) {
+            formData.append(key, data[root][key]);
+          } else {
+            formData.append(root + "[" + key + "]", data[root][key]);
+          }
         }
       });
 

--- a/tests/unit/mixins/form-data-adapter-test.js
+++ b/tests/unit/mixins/form-data-adapter-test.js
@@ -38,7 +38,7 @@ test('#ajaxOptions', function() {
       post: {
         id: 1,
         title: 'Rails is Omakase'
-      }            
+      }
     }
   };
 
@@ -56,9 +56,36 @@ test('Falsey key gets saved', function() {
     data: {
       post: {
         preferred: false
-      }            
+      }
     }
   };
+
+  var hash = adapter.ajaxOptions('/', 'POST', options);
+
+  deepEqual(hash.data, testFormData);
+});
+
+test('Default disableRoot', function() {
+  deepEqual(adapter.get('disableRoot'), false);
+});
+
+test('#ajaxOptions should exclude root when disableRoot is true', function() {
+  var testFormData = new window.FormData();
+
+  // Setup expected form data; note the lack of the 'post' root (post[id])
+  testFormData.append('id', 1);
+  testFormData.append('title', 'Rails is Omakase');
+
+  var options = {
+    data: {
+      post: {
+        id: 1,
+        title: 'Rails is Omakase'
+      }
+    }
+  };
+
+  adapter.set('disableRoot', true);
 
   var hash = adapter.ajaxOptions('/', 'POST', options);
 


### PR DESCRIPTION
Supposing you have a post model with 'id' and 'title' fields. The default
adapter would have form data fields of 'post[id]' and 'post[title]'.
Enabling the 'disableRoot' flag would instead have form data fields of
'id' and 'post'.

To enable this feature add `disableRoot: true` in your adapter.