### PR TITLE
Update form-data-adapter.js for keys with no value

### DIFF
--- a/addon/mixins/form-data-adapter.js
+++ b/addon/mixins/form-data-adapter.js
@@ -28,7 +28,7 @@ export default Ember.Mixin.create({
     var root = Object.keys(data)[0];
 
     Object.keys(data[root]).forEach(function(key) {
-      if (typeof data[root][key] !== 'undefined') {
+      if (typeof data[root][key] !== 'undefined' && data[root][key] !== null) {
         if (this.get('disableRoot') ) {
           formData.append(key, data[root][key]);
         } else {


### PR DESCRIPTION
Sometime a form can hold keys with no value.
Serialized, these keys have value of `"null"`