### PR TITLE
fix ember 3.9 issue

### DIFF
--- a/addon/mixins/form-data-adapter.js
+++ b/addon/mixins/form-data-adapter.js
@@ -18,6 +18,9 @@ export default Mixin.create({
     if (typeof FormData !== 'undefined' && data && this.formDataTypes.indexOf(type) >= 0) {
       hash.processData = false;
       hash.contentType = false;
+      if (typeof hash.headers !== 'undefined') {
+        delete hash.headers['content-type'];
+      }
       hash.data = this._getFormData(data);
     }
 


### PR DESCRIPTION
In recent Ember versions, Ember Data adapter sets header's content type to json which breaks form data request.

We should remove it.